### PR TITLE
feat(defaults): Add retro and blank defaults

### DIFF
--- a/src/GravatarPlugin.php
+++ b/src/GravatarPlugin.php
@@ -49,7 +49,7 @@ class GravatarPlugin implements Plugin
      */
     public function default(string $default): static
     {
-        if (! in_array($default, ['404', 'mp', 'identicon', 'monsterid', 'wavatar', 'robohash'])) {
+        if (! in_array($default, ['404', 'mp', 'identicon', 'monsterid', 'wavatar', 'retro', 'robohash', 'blank'])) {
             throw new Exception('Invalid default');
         }
 


### PR DESCRIPTION
Adds support for 
* retro: awesome generated, 8-bit arcade-style pixelated faces
* blank: a transparent PNG image (border added to HTML below for demonstration purposes)

---
https://docs.gravatar.com/api/avatars/images/#:~:text=retro%3A%20awesome%20generated%2C%208%2Dbit%20arcade%2Dstyle%20pixelated%20faces