### PR TITLE
fix: Correct old namespace in upgrade documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Replace Filament's default avatar url provider with one for Gravatar.
 
 ## Upgrading from v2 to v3
 
-If you are upgrading from version 2 to version 3, you will need to update the namespace anywhere you are using the plugin from `Awcodes\Gravatar` to `Awcodes\Gravatar`.
+If you are upgrading from version 2 to version 3, you will need to update the namespace anywhere you are using the plugin from `Awcodes\FilamentGravatar` to `Awcodes\Gravatar`.
 
 ## Installation
 


### PR DESCRIPTION
The README previously stated that the namespace to be updated was `Awcodes\Gravatar`, but the correct **old** namespace is `Awcodes\FilamentGravatar`.
